### PR TITLE
feat: Add Gemini 2.5 models and enhance UI feedback

### DIFF
--- a/css/shogi.css
+++ b/css/shogi.css
@@ -35,10 +35,16 @@
     box-shadow: 0 0 10px rgba(142, 107, 72, 0.8);
 }
 
+.square.last-move {
+    background-color: rgba(255, 204, 0, 0.5); /* 最後の移動先をハイライト */
+}
+
+
 .piece-captured.selected {
     border-radius: 5px;
     background-color: #fdfd96;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
+    filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.7));
 }
 
 .square.valid-move {
@@ -52,6 +58,12 @@
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
+    transition: transform 0.1s ease-in-out, filter 0.1s ease-in-out;
+}
+
+.square.selected .piece {
+    transform: scale(1.05);
+    filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.7));
 }
 
 /* プレイヤーごとの駒の向き */


### PR DESCRIPTION
This commit introduces several enhancements to the Gemini Shogi plugin:

1.  **UI/UX Improvements:**
    - Adds visual feedback for the last move on the board.
    - Enhances the styling for selected pieces (both on the board and in hand) to make them more prominent, using shadows and scaling effects.

2.  **Expanded AI Model Selection:**
    - Updates the available Gemini models in the UI to the 2.5 series (Pro, Flash, Flash-Lite) as you requested.
    - Adds a model selector to the Player vs. AI mode, allowing you to choose which AI to face.
    - Adds a second model selector to the AI vs. AI mode, allowing for flexible matchups like Gemini vs. Gemini.

NOTE: I was unable to update the backend PHP file (`gemini-shogi.php`) to handle the new frontend logic due to a persistent, unresolvable issue. The backend handlers for Player vs. AI and AI vs. AI moves still need to be updated to parse the new `api_provider` and `model_name` parameters from the requests.